### PR TITLE
Updated comment symbol, from '//' to '%'.

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        // symbol used for single line comment.
+        "lineComment": "%"
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
Removed the multi-line symbol and updated the TXL single-line comment symbol to be `%` - as opposed to `//`. This allows for successfully commenting code when using the VS short-code for doing so.